### PR TITLE
Split includes of ServiceMacros.h into declaration and definition parts to avoid warnings from art

### DIFF
--- a/ifdh_art/IFBeamService/IFBeam_service.cc
+++ b/ifdh_art/IFBeamService/IFBeam_service.cc
@@ -1,5 +1,7 @@
 #include "IFBeam_service.h"
 
+#include "art/Framework/Services/Registry/ServiceDefinitionMacros.h"
+
 // DEFINE_ART_SERVICE(ifbeam_ns::IFBeam)
 DEFINE_ART_SERVICE(ifbeam_ns::IFBeam)
 

--- a/ifdh_art/IFBeamService/IFBeam_service.h
+++ b/ifdh_art/IFBeamService/IFBeam_service.h
@@ -5,7 +5,7 @@
 
 #include "fhiclcpp/ParameterSet.h"
 #include "art/Framework/Services/Registry/ActivityRegistry.h"
-#include "art/Framework/Services/Registry/ServiceMacros.h"
+#include "art/Framework/Services/Registry/ServiceDeclarationMacros.h"
 
 
 namespace ifbeam_ns {

--- a/ifdh_art/IFCatalogInterface/IFCatalogInterface.cc
+++ b/ifdh_art/IFCatalogInterface/IFCatalogInterface.cc
@@ -2,7 +2,7 @@
 #include "art/Framework/Services/FileServiceInterfaces/FileDeliveryStatus.h"
 #include "art/Framework/Services/FileServiceInterfaces/CatalogInterface.h"
 #include "art/Framework/Services/Registry/ActivityRegistry.h"
-#include "art/Framework/Services/Registry/ServiceMacros.h"
+#include "art/Framework/Services/Registry/ServiceDefinitionMacros.h"
 #include "art/Framework/Services/Registry/detail/ServiceHelper.h"
 
 #include "messagefacility/MessageLogger/MessageLogger.h"

--- a/ifdh_art/IFCatalogInterface/IFCatalogInterface_service.h
+++ b/ifdh_art/IFCatalogInterface/IFCatalogInterface_service.h
@@ -4,7 +4,7 @@
 #include "art/Framework/Services/Registry/ServiceHandle.h"
 #include "fhiclcpp/ParameterSet.h"
 #include "art/Framework/Services/Registry/ActivityRegistry.h"
-#include "art/Framework/Services/Registry/ServiceMacros.h"
+#include "art/Framework/Services/Registry/ServiceDeclarationMacros.h"
 #include "art/Framework/Services/FileServiceInterfaces/CatalogInterface.h"
 #include <vector>
 

--- a/ifdh_art/IFDHService/IFDH_service.cc
+++ b/ifdh_art/IFDHService/IFDH_service.cc
@@ -1,3 +1,5 @@
 #include "ifdh_art/IFDHService/IFDH_service.h"
 
+#include "art/Framework/Services/Registry/ServiceDefinitionMacros.h"
+
 DEFINE_ART_SERVICE(ifdh_ns::IFDH)

--- a/ifdh_art/IFDHService/IFDH_service.h
+++ b/ifdh_art/IFDHService/IFDH_service.h
@@ -4,7 +4,7 @@
 
 // art bits...
 #include "fhiclcpp/ParameterSet.h"
-#include "art/Framework/Services/Registry/ServiceMacros.h"
+#include "art/Framework/Services/Registry/ServiceDeclarationMacros.h"
 
 namespace ifdh_ns {
 

--- a/ifdh_art/IFFileTransfer/IFFileTransfer_service.cc
+++ b/ifdh_art/IFFileTransfer/IFFileTransfer_service.cc
@@ -1,3 +1,5 @@
 #include "IFFileTransfer_service.h"
 
+#include "art/Framework/Services/Registry/ServiceDefinitionMacros.h"
+
 DEFINE_ART_SERVICE_INTERFACE_IMPL(ifdh_ns::IFFileTransfer, art::FileTransfer)

--- a/ifdh_art/IFFileTransfer/IFFileTransfer_service.h
+++ b/ifdh_art/IFFileTransfer/IFFileTransfer_service.h
@@ -4,7 +4,7 @@
 #include "art/Framework/Services/Registry/ActivityRegistry.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
 #include "fhiclcpp/ParameterSet.h"
-#include "art/Framework/Services/Registry/ServiceMacros.h"
+#include "art/Framework/Services/Registry/ServiceDeclarationMacros.h"
 #include "art/Framework/Services/FileServiceInterfaces/FileTransfer.h"
 
 #include "ifdh_art/IFDHService/IFDH_service.h"

--- a/ifdh_art/NUconDBService/NUconDB_service.cc
+++ b/ifdh_art/NUconDBService/NUconDB_service.cc
@@ -1,4 +1,6 @@
 #include "NUconDB_service.h"
 
+#include "art/Framework/Services/Registry/ServiceDefinitionMacros.h"
+
 //DEFINE_ART_SERVICE(nucondb_ns::nucondbService)
 DEFINE_ART_SERVICE(nucondb_ns::NUconDBService)

--- a/ifdh_art/NUconDBService/NUconDB_service.h
+++ b/ifdh_art/NUconDBService/NUconDB_service.h
@@ -6,7 +6,7 @@
 #include "fhiclcpp/ParameterSet.h"
 #include "art/Framework/Services/Registry/ActivityRegistry.h"
 #include "art/Framework/Services/Registry/ServiceHandle.h"
-#include "art/Framework/Services/Registry/ServiceMacros.h"
+#include "art/Framework/Services/Registry/ServiceDeclarationMacros.h"
 #include "cetlib_except/exception.h"
 
 namespace nucondb_ns {


### PR DESCRIPTION
Otherwise user code hits this

<pre>
/cvmfs/larsoft.opensciencegrid.org/products//art/v3_09_03/include/art/Framework/Services/Registry/ServiceMacros.h:4:3: warning: art/Framework/Services/Registry/ServiceDeclarationMacros.h or art/Framework/Services/Registry/ServiceDefinitionMacros.h should be included separately as appropriate to minimize transitive dependencies
    4 |   "art/Framework/Services/Registry/ServiceDeclarationMacros.h or art/Framework/Services/Registry/ServiceDefinitionMacros.h should be included separately as appropriate to minimize transitive dependencies"
</pre>